### PR TITLE
Recipient show page

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,10 @@
 exit
+next
+recipient_id
+exit
+recipient_ids
+recipient_id
+exit
 @charity
 params
 exit

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,6 @@
 exit
+need_categories
+exit
 next
 recipient_id
 exit

--- a/app/controllers/causes_controller.rb
+++ b/app/controllers/causes_controller.rb
@@ -1,6 +1,6 @@
 class CausesController < ApplicationController
   def show
     @cause = Cause.find_by(slug: params[:causes_slug])
-    @recipients = @cause.recipients
+    @recipients = @cause.active_recipients
   end
 end

--- a/app/controllers/charities_controller.rb
+++ b/app/controllers/charities_controller.rb
@@ -6,5 +6,6 @@ class CharitiesController < ApplicationController
 
   def show
     @charity = Charity.find_by(slug: params[:charity_slug])
+    @recipients = @charity.active_recipients
   end
 end

--- a/app/controllers/charity/recipients_controller.rb
+++ b/app/controllers/charity/recipients_controller.rb
@@ -9,7 +9,7 @@ class Charity::RecipientsController < ApplicationController
   def show
     @charity = Charity.find_by(slug: params[:charity]) #change
     @recipient = Recipient.find(params[:id])
-    @items = @recipient.need_items.active
+    @items = @recipient.active_need_items
     if !@charity.associated_recipient?(@recipient.id)
        flash[:info] = "Recipient not found"
        redirect_to charity_path(@charity.slug)

--- a/app/controllers/charity/recipients_controller.rb
+++ b/app/controllers/charity/recipients_controller.rb
@@ -7,18 +7,12 @@ class Charity::RecipientsController < ApplicationController
   end
 
   def show
-    # byebug
     @charity = Charity.find_by(slug: params[:charity]) #change
     @recipient = Recipient.find(params[:id])
     @items = @recipient.need_items.active
-    # if @family.value_of_supplies_purchased > 0
-    #   @supplies_needed_value = @family.value_of_supplies_needed
-    #   @supplies_purchased_value = @family.value_of_supplies_purchased
-    #   @percentage_purchased = @family.percentage_donated
-    # else
-    #   @supplies_needed_value = @family.value_of_supplies_needed
-    #   @supplies_purchased_value = 0
-    #   @percentage_purchased = 0
-    # end
+    if !@charity.associated_recipient?(@recipient.id)
+       flash[:info] = "Recipient not found"
+       redirect_to charity_path(@charity.slug)
+    end
   end
 end

--- a/app/controllers/needs_categories_controller.rb
+++ b/app/controllers/needs_categories_controller.rb
@@ -2,6 +2,7 @@ class NeedsCategoriesController < ApplicationController
 
   def show
     @needs_category = NeedsCategory.find_by(slug: params[:needs_category_slug])
+    @recipients = @needs_category.active_recipients
   end
 
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -9,4 +9,8 @@ class Cause < ActiveRecord::Base
   def create_slug
     self.slug = self.name.parameterize
   end
+
+  def active_recipients
+    recipients.find_all { |recipient| !recipient.active_need_items.empty? }
+  end
 end

--- a/app/models/charity.rb
+++ b/app/models/charity.rb
@@ -14,12 +14,15 @@ class Charity < ActiveRecord::Base
 
   def associated_recipient?(recipient_id)
     recipient_ids = recipients.pluck(:id)
-    # byebug
     if recipient_ids.include?(recipient_id)
       true
     else
       false
     end
+  end
+
+  def active_recipients
+    recipients.find_all { |recipient| !recipient.active_need_items.empty? }
   end
 
 end

--- a/app/models/charity.rb
+++ b/app/models/charity.rb
@@ -12,4 +12,14 @@ class Charity < ActiveRecord::Base
     self.slug = self.name.parameterize
   end
 
+  def associated_recipient?(recipient_id)
+    recipient_ids = recipients.pluck(:id)
+    # byebug
+    if recipient_ids.include?(recipient_id)
+      true
+    else
+      false
+    end
+  end
+
 end

--- a/app/models/need_item.rb
+++ b/app/models/need_item.rb
@@ -6,9 +6,14 @@ class NeedItem < ActiveRecord::Base
   scope :retired, -> {where("deadline < ?", Date.today)}
   scope :active, -> {where("deadline > ?", Date.today)}
 
+
   # def self.find_family(id)
   #   find(id).family
   # end
+
+  def active_need_item
+    deadline > Date.today && quantity_remaining > 0
+  end
 
   def name
     need.name

--- a/app/models/needs_category.rb
+++ b/app/models/needs_category.rb
@@ -8,4 +8,9 @@ class NeedsCategory < ActiveRecord::Base
   def create_slug
     self.slug = self.name.parameterize
   end
+
+  def active_recipients
+    recipients.find_all { |recipient| !recipient.active_need_items.empty? }
+  end
+
 end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -18,6 +18,10 @@ class Recipient < ActiveRecord::Base
   scope :retired, -> {where("arrival_date < ?", Date.today)}
   scope :active, -> {where("arrival_date > ?", Date.today)}
 
+  def active_need_items
+    need_items.find_all { |item| item.active_need_item }
+  end
+
   def num_people
     num_married_adults + num_unmarried_adults +
     num_children_over_two + num_children_under_two

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -3,8 +3,9 @@ class Recipient < ActiveRecord::Base
   validates :description, presence: true
 
   has_many :need_items
+  has_many :needs, through: :need_items
+  has_many :need_categories, through: :needs
   has_many :donation_items, through: :need_items
-  belongs_to :charity
   belongs_to :charity
 
   has_attached_file :recipient_photo, styles: {
@@ -20,6 +21,10 @@ class Recipient < ActiveRecord::Base
 
   def active_need_items
     need_items.find_all { |item| item.active_need_item }
+  end
+
+  def need_categories
+    needs.map {|need| need.needs_category}.uniq
   end
 
   def num_people

--- a/app/views/causes/show.html.erb
+++ b/app/views/causes/show.html.erb
@@ -1,2 +1,2 @@
 <h1> <%= @cause.name %></h1>
-<%= render partial: "shared/recipient_list", locals: {category: @cause } %>
+<%= render partial: "shared/recipient_list" %>

--- a/app/views/charities/show.html.erb
+++ b/app/views/charities/show.html.erb
@@ -1,3 +1,3 @@
 <h1><%= @charity.name %></h1>
   <p><%= @charity.description %></p>
-<%= render partial: "shared/recipient_list", locals: {category: @charity } %>
+<%= render partial: "shared/recipient_list" %>

--- a/app/views/charity/recipients/show.html.erb
+++ b/app/views/charity/recipients/show.html.erb
@@ -1,11 +1,11 @@
 <div class="recipient-info">
-  <h4><%= @recipient.name  %> </h4>
-  <p><%= @recipient.description %></p>
+  <h4>Recipient: <%= @recipient.name  %> </h4>
+  <p>Descrption:<%= @recipient.description %></p>
 </div>
 
 <div class="charity-info">
-  <h4><%= @charity.name  %> </h4>
-  <p><%= @charity.description %></p>
+  <h4>Charity: <%= @charity.name  %> </h4>
+  <p>Description: <%= @charity.description %></p>
 </div>
 
 <% if !@items.empty? %>
@@ -21,7 +21,6 @@
       </tr>
 
     <% @items.each do |item| %>
-      <% if item.quantity_remaining > 0 %>
         <%= form_for item, url: cart_items_path, method: :create do |f| %>
           <div class='<%= item.name %>' >
             <tr>
@@ -37,7 +36,6 @@
             </tr>
           </div>
         <% end %>
-      <% end %>
     <% end %>
     </table>
   </div>

--- a/app/views/charity/recipients/show.html.erb
+++ b/app/views/charity/recipients/show.html.erb
@@ -1,3 +1,4 @@
+<div class="container">
 <div class="recipient-info">
   <h4>Recipient: <%= @recipient.name  %> </h4>
   <p>Descrption:<%= @recipient.description %></p>
@@ -7,9 +8,10 @@
   <h4>Charity: <%= @charity.name  %> </h4>
   <p>Description: <%= @charity.description %></p>
 </div>
+</div>
 
 <% if !@items.empty? %>
-  <div class="col-sm-10 col-sm-offset-1 current-needs">
+  <div class="col-sm-12 current-needs">
 
     <h4><%=@recipient.name %> needs the following donations:</h4>
     <table class="table">
@@ -42,3 +44,18 @@
 <% else %>
   <h4><%= @recipient.name %> has no current donation needs</h4>
 <% end  %>
+
+<div class="container">
+
+<h4>See more recipients like <%= @recipient.name %>:</h4>
+<div class="btn-group-vertical" role="group">
+  <%= button_to "All from #{@recipient.charity.name}",  charity_path(@recipient.charity.slug), method: :get, class: 'btn btn-info btn-block'%>
+  <% @recipient.charity.causes.each do |cause| %>
+  <%= button_to "All from #{cause.name} Cause",  cause_path(cause.slug), method: :get, class: 'btn btn-info btn-block' %>
+  <% end %>
+  <% @recipient.need_categories.each do |category| %>
+  <%= button_to "All with #{category.name} Need",  needs_category_path(category.slug), method: :get, class: 'btn btn-info btn-block' %>
+  <% end %>
+</div>
+
+</div>

--- a/app/views/needs_categories/show.html.erb
+++ b/app/views/needs_categories/show.html.erb
@@ -1,3 +1,3 @@
 <h1><%= @needs_category.name %></h1>
 
-<%= render partial: "shared/recipient_list", locals: {category: @needs_category} %>
+<%= render partial: "shared/recipient_list" %>

--- a/app/views/shared/_recipient_list.html.erb
+++ b/app/views/shared/_recipient_list.html.erb
@@ -1,5 +1,5 @@
 <ul>
-  <% category.recipients.each do |recipient| %>
+  <% @recipients.each do |recipient| %>
   <li><%= link_to recipient.name, charity_recipient_path(recipient.charity.slug, recipient) %></li>
       <p><%= recipient.description %><p>
   <% end %>

--- a/spec/features/user_can_view_recipients_by_cause_spec.rb
+++ b/spec/features/user_can_view_recipients_by_cause_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.feature "User Can View the Recipients by Cause" do
   scenario "user navigates to recipients from cause" do
-  recipient = create(:recipient)
+  recipient = create(:future_need_item).recipient
   cause = create(:cause)
   recipient.charity.causes << cause
 
   visit root_path
 
-  click_on "Cause-1"
+  click_on "#{cause.name}"
 
   expect(current_path).to eq(cause_path(cause.slug))
 

--- a/spec/features/user_can_view_recipients_by_charity_spec.rb
+++ b/spec/features/user_can_view_recipients_by_charity_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.feature "User Can View the Recipients by Charity" do
   scenario "user navigates to recipients from root" do
-  recipient_one, recipient_two = create_list(:recipient, 2)
+
+  recipient_one = create(:future_need_item).recipient
 
   visit root_path
 
@@ -12,7 +13,7 @@ RSpec.feature "User Can View the Recipients by Charity" do
 
   expect(page).to have_content("All Charities")
 
-  click_on "Charity-1"
+  click_on "#{recipient_one.charity.name}"
 
   expect(current_path).to eq(charity_path(recipient_one.charity.slug))
 

--- a/spec/features/user_can_view_recipients_by_charity_spec.rb
+++ b/spec/features/user_can_view_recipients_by_charity_spec.rb
@@ -22,4 +22,5 @@ RSpec.feature "User Can View the Recipients by Charity" do
   click_on "#{recipient_one.name}"
   expect(current_path).to eq(charity_recipient_path(recipient_one.charity.slug, recipient_one))
   end
+
 end

--- a/spec/features/user_sees_correct_info_on_family_show_spec.rb
+++ b/spec/features/user_sees_correct_info_on_family_show_spec.rb
@@ -116,4 +116,17 @@ RSpec.feature "user sees correct info for recipients" do
 
   end
 
+
+
+    scenario "they don't see a recipient for another charity through the charity path" do
+      charity, other_charity = create_list(:charity, 2)
+      other_recipient = other_charity.recipients.create(name: "test", description: "test")
+
+      visit charity_recipient_path(charity.slug, other_recipient)
+
+      expect(current_path).to eq(charity_path(charity.slug))
+      expect(page).to have_content("Recipient not found")
+
+    end
+
 end


### PR DESCRIPTION
Adds the following:
1. User cannot forcibly enter a recipient id not associated with a charity on a url  Closes #31
2.  Figured out my bug on show page that caused forms to be empty (it was because all items for those recipients had been fully donated and my if/else logic was misplaced).
3. As a result I realized that our cause/category/charity show pages had many recipients with no current needs.  I added logic to only display those with outstanding donation needs.
